### PR TITLE
Added tsd dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "body-parser": "^1.14.2",
     "express": "^4.13.3",
+    "tsd": "^0.6.5",
     "typescript": "1.7.5"
   }
 }


### PR DESCRIPTION
`npm install` was failing due to tsd command not being found.



```bash
$ npm install
 
> zone.js@0.5.11 postinstall $DEVROOT/fkem-content-manager/node_modules/zone.js
> tsd install

sh: tsd: command not found
npm ERR! Darwin 14.5.0
npm ERR! argv "~/.nvm/versions/node/v4.2.4/bin/node" "~/.nvm/versions/node/v4.2.4/bin/npm" "install"
npm ERR! node v4.2.4
npm ERR! npm  v2.14.12
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn

npm ERR! zone.js@0.5.11 postinstall: `tsd install`
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the zone.js@0.5.11 postinstall script 'tsd install'.
npm ERR! This is most likely a problem with the zone.js package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     tsd install
npm ERR! You can get their info via:
npm ERR!     npm owner ls zone.js
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     $DEVROOT/fkem-content-manager/npm-debug.log
```
**log modified to remove attack vectors**